### PR TITLE
Fix: Update branch name and handle errors


### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
                 "--base_branch",
                 "origin/main",
                 "--current_branch",
-                "test1",
+                "test",
             ],
         }
     ]

--- a/create_pr.py
+++ b/create_pr.py
@@ -30,7 +30,7 @@ def get_git_diff(base_branch: str, current_branch: str) -> str:
         return diff
     except subprocess.CalledProcessError as e:
         print(f"Error getting git diff: {e}")
-        return ""
+        exit(1)
 
 
 def generate_title_and_description(diff: str) -> tuple[str, str]:
@@ -84,6 +84,7 @@ def create_pr(title: str, description: str, current_branch: str, base_branch: st
     else:
         print("Failed to create PR.")
         print(f"Error: {error.decode('utf-8')}")
+        exit(1)
 
 
 def main():

--- a/create_pr.py
+++ b/create_pr.py
@@ -73,7 +73,7 @@ def create_pr(title: str, description: str, current_branch: str, base_branch: st
     description = description.replace("'", "'\\''")
     command = f"gh pr create --title '{title}' --body '{description}' --head {current_branch} --base {base_branch}"
     process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    output, error = process.communicate()
+    _, error = process.communicate()
 
     # Check if the PR was created successfully
     if process.returncode == 0:


### PR DESCRIPTION
OK. Let's break down these code changes.

**1. `.vscode/launch.json`**

```diff
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
                 "--base_branch",
                 "origin/main",
                 "--current_branch",
-                "test1",
+                "test",
             ],
         }
     ]
```

*   **Change:** The `current_branch` argument passed to the debug configuration has been changed from `"test1"` to `"test"`.

*   **Reason:** This indicates that the developer is likely now working on a branch named "test" instead of "test1".  The launch configuration needs to be updated to reflect the correct branch name so that the program is executed with the appropriate parameters for the current development context.

**2. `create_pr.py`**

```diff
--- a/create_pr.py
+++ b/create_pr.py
@@ -30,7 +30,7 @@ def get_git_diff(base_branch: str, current_branch: str) -> str:
         return diff
     except subprocess.CalledProcessError as e:
         print(f"Error getting git diff: {e}")
-        return ""
+        exit(1)
```

*   **Change:** In the `get_git_diff` function, the `return ""` statement within the `except` block has been replaced with `exit(1)`.

*   **Reason:**  This change modifies the error handling within the `get_git_diff` function. Previously, if the `git diff` command failed, the function would print an error message and return an empty string. Now, the function will print the error message and immediately terminate the script (exit with a status code of 1). This is a more aggressive error handling strategy. Returning an empty string could lead to unexpected behavior later in the script if the `diff` variable is used without proper validation.  Exiting ensures that the script stops when it encounters a critical error like failing to retrieve the git diff.

```diff
--- a/create_pr.py
+++ b/create_pr.py
@@ -73,7 +73,7 @@ def create_pr(title: str, description: str, current_branch: str, base_branch: st
     description = description.replace("'", "'\\''")
     command = f"gh pr create --title '{title}' --body '{description}' --head {current_branch} --base {base_branch}"
     process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    output, error = process.communicate()
+    _, error = process.communicate()
```

*   **Change:**  In the `create_pr` function, the `output` variable from `process.communicate()` is discarded.

*   **Reason:** The code now only cares about the `error` output from the `gh pr create` command. The `output` was not being used anywhere, so the assignment has been changed to `_` to indicate that the variable is intentionally ignored. This makes the code cleaner and more explicit about its intent.

```diff
--- a/create_pr.py
+++ b/create_pr.py
@@ -84,6 +84,7 @@ def create_pr(title: str, description: str, current_branch: str, base_branch: st
     else:
         print("Failed to create PR.")
         print(f"Error: {error.decode('utf-8')}")
+        exit(1)
```

*   **Change:**  In the `create_pr` function, an `exit(1)` call has been added to the `else` block, which executes when the PR creation fails.

*   **Reason:**  Similar to the change in `get_git_diff`, this makes the error handling more robust. If the `gh pr create` command fails (indicated by a non-zero return code), the function now prints an error message and then terminates the script. Previously, the script would continue running even after failing to create the PR, which could lead to further issues or unexpected behavior.  Exiting indicates that the script failed to complete successfully.

In summary, these changes aim to:

*   **Correct the branch name** used in debugging configuration.
*   **Improve error handling** by exiting the script upon encountering errors during git diff retrieval and PR creation, rather than attempting to proceed with potentially invalid data or a failed PR. This prevents the script from continuing in a broken state.
*   **Clean up the code** by removing unused variables.