### PR TITLE
Add support for PR description templates

### DIFF
--- a/create_pr.py
+++ b/create_pr.py
@@ -9,6 +9,7 @@ from utils.print_utils import (
     blue_print,
 )
 from utils.cli import create_parser
+import glob
 from utils.git_utils import get_git_branches, get_git_diff
 
 load_dotenv(dotenv_path=".env")
@@ -68,12 +69,19 @@ def main():
     # Get the git diff
     diff = get_git_diff(base_branch, current_branch, repo_path)
 
+    # Load PR description templates from the templates folder
+    template_dir = "templates"
+    templates = []
+    for template_file in glob.glob(os.path.join(template_dir, "*.md")):
+        with open(template_file, "r") as f:
+            templates.append(f.read())
+
     # Generate the title and description of the PR
     if title:
-        description = generate_title_and_description(diff)[1]
+        description = generate_title_and_description(diff, templates=templates)[1]
     else:
         try:
-            title, description = generate_title_and_description(diff)
+            title, description = generate_title_and_description(diff, templates=templates)
         except Exception as e:
             red_print(f"Error generating title and description: {e}")
             exit(1)

--- a/templates/example_readme.md
+++ b/templates/example_readme.md
@@ -1,0 +1,17 @@
+🎫 Jira Ticket
+[Please link to the Jira ticket here.]
+
+📝 Summary
+Provide a brief description of the changes included in this PR. Include any context or reasoning that would help reviewers understand your changes.
+
+⚠️ Important Changes
+Highlight any important changes or considerations here, such as database migrations, environment changes, etc.
+
+🔗 Related PRs (Optional)
+[List any related PRs here. This section is optional. If there are no related PRs, you can remove this section.]
+
+🧪 How to Test
+Describe the steps needed to test the functionality of the changes made in this PR. Include specific commands, environments, or data necessary to perform the test.
+
+🎨 Figma Designs (If Needed)
+[If there are Figma designs associated with this PR, please link them here. Include any specific frames or versions reviewers should look at.]


### PR DESCRIPTION
📝 Summary
This PR introduces the ability to use templates for generating PR descriptions using the Gemini AI model. It adds functionality to load templates from a "templates" directory, and passes them to the `generate_title_and_description` function.  The LLM utils are modified to leverage these templates when creating the PR description, allowing for a more structured and consistent output. An example template file is also included.

⚠️ Important Changes
A new directory named "templates" is expected at the root level containing markdown files to be used as PR description templates.

🧪 How to Test
1.  Create a `templates` directory at the root of the project.
2.  Place one or more markdown files (e.g., `example_readme.md`) containing PR description templates inside the `templates` directory.
3.  Run the `create_pr.py` script.
4.  Verify that the generated PR description incorporates the structure and content from the templates.